### PR TITLE
Add missing closing bracket in the documentation

### DIFF
--- a/src/pyDataverse/api.py
+++ b/src/pyDataverse/api.py
@@ -629,7 +629,7 @@ class Api(object):
         <http://guides.dataverse.org/en/latest/_downloads/dataset-finch1.json>`_.
         Then, you must decide which dataverse to create the dataset in and
         target that datavese with either the "alias" of the dataverse (e.g.
-        "root" or the database id of the dataverse (e.g. "1"). The initial
+        "root") or the database id of the dataverse (e.g. "1"). The initial
         version state will be set to DRAFT:
 
         Status Code:


### PR DESCRIPTION
Just adding a missing closing bracket in the [Developer Interface](https://pydataverse.readthedocs.io/en/latest/developer.html#pyDataverse.api.Api.create_dataset) section.

Closes issue #40.